### PR TITLE
Add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pyllr"
+version = "0.0.1"
+authors = [
+  { name="Niko Brummer", email="niko.brummer@gmail.com" },
+]
+description = "Python package for the log-likelihood-ratio"
+license = { file = "LICENSE" }
+readme = "README.md"
+requires-python = ">=3.7"
+dependencies = [ "matplotlib", "numpy", "scipy", "sklearn" ]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/bsxfan/PYLLR"
+"Bug Tracker" = "https://github.com/bsxfan/PYLLR/issues"


### PR DESCRIPTION
When I install using `pip install git+https://github.com/bsxfan/PYLLR.git`, I now get nasty warnings `DEPRECATION: pyllr is being installed using the legacy 'setup.py install' method, because it does not have a 'pyproject.toml' and the 'wheel' package is not installed. pip 23.1 will enforce this behaviour change. A possible replacement is to enable the '--use-pep517' option. Discussion can be found at https://github.com/pypa/pip/issues/8559`, so this is an attempt to get rid of this and make it more future-proof. 

Also, it prepares for publishing on pypi (I recently published my [first package](https://pypi.org/project/worderrorrate/) there) so ideally the installation instructions could be in the future:
```
pip install pyllr
```
