### PR TITLE
Change dependency sklearn to scikit-learn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyllr"
-version = "0.0.1"
+version = "0.0.2"
 authors = [
   { name="Niko Brummer", email="niko.brummer@gmail.com" },
 ]
@@ -12,7 +12,7 @@ description = "Python package for the log-likelihood-ratio"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.7"
-dependencies = [ "matplotlib", "numpy", "scipy", "sklearn" ]
+dependencies = [ "matplotlib", "numpy", "scipy", "scikit-learn" ]
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-matplotlib==3.4.1
-numpy==1.20.2
-scipy==1.6.2
-sklearn==0.0
+matplotlib>=3.4.1
+numpy>=1.20.2
+scipy>=1.6.2
+scikit-learn>=1.2

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '0.0.1' 
+VERSION = '0.0.2' 
 DESCRIPTION = 'Python package for log-likelihood-ratio'
 LONG_DESCRIPTION = 'Python package for log-likelihood-ratio'
 


### PR DESCRIPTION
...which apparently is the preferred way, and as per quite recently `sklearn` is depricated

Also changes exact requirements to minimum requirements